### PR TITLE
fix issue: invalid read from stack off -16+6 size 8

### DIFF
--- a/sockdump.py
+++ b/sockdump.py
@@ -144,7 +144,8 @@ def build_filter(sock_path):
         sock_path_bytes = sock_path_bytes[:-1]
     else:
         sock_path_bytes += b'\0'
-    n = len(sock_path_bytes)
+    # make size of path in bpf prog divisible by 8
+    n = (len(sock_path_bytes) + 7) & ~(7)
     if n > UNIX_PATH_MAX:
         raise ValueError('invalid path')
     # match all paths


### PR DESCRIPTION
Use sockdump in kernel version 4.19. bpf verify fail.
log is here:
149: (79) r1 = *(u64 *)(r10 -16)
invalid read from stack off -16+6 size 8

The corresponding code is here:
__PATH_FILTER__

python code will replace it. just like this:
if (path[0] == 47 && ... && path[37] == 0)
	math = 1;

check byte code like this:
43: (18) r2 = 0xffffffff00000000
45: (79) r1 = *(u64 *)(r10 -48)
46: (bf) r3 = r1
47: (5f) r3 &= r2
48: (18) r2 = 0x6e6f632f00000000
50: (b7) r7 = 0
51: (5d) if r3 != r2 goto pc+129

It can be found that the compiler has optimized and used 8-byte access
for comparison, so the problem also arises. When bpf prog performs
8-byte access, it is necessary to ensure that the address is 8-byte
aligned, and we are determining the path array of size, just count the
number of strings and add '\0'.

The solution is relatively simple, ensuring that the path size is
divisible by 8.

Signed-off-by: Feng Zhou <zhoufeng.zf@bytedance.com>