### PR TITLE
Pcap stdout: make sure stdout is wb

### DIFF
--- a/sockdump.py
+++ b/sockdump.py
@@ -366,8 +366,7 @@ def main(args):
     signal.signal(signal.SIGTERM, sig_handler)
 
     if args.format == 'pcap':
-        if args.output != '/dev/stdout':
-            sys.stdout = open(args.output, 'wb')
+        sys.stdout = open(args.output, 'wb')
         pcap_write_header(args.seg_size, PCAP_LINK_TYPE)
     else:
         if args.output != '/dev/stdout':


### PR DESCRIPTION
On Python 3.10.12, stdout is opened in 'w' mode by default:

```
  Python 3.10.12 (main, Jun  6 2023, 22:43:10) [GCC 12.3.0] on linux
  Type "help", "copyright", "credits" or "license" for more information.
  >>> import sys
  >>> sys.stdout.mode
  'w'
```

In pcap capture mode, we're trying to write some binary data directly to stdout, which yields to the following error:

```
  » sudo sockdump --format pcap /nix/var/nix/daemon-socket/socket
  Traceback (most recent call last):
    File "/nix/store/dl5l4k2xrrxcay3hh9034p4jnfiq0ihg-sockdump-unstable-2023-07-13/bin/.sockdump-wrapped", line 413, in <module>
      main(args)
    File "/nix/store/dl5l4k2xrrxcay3hh9034p4jnfiq0ihg-sockdump-unstable-2023-07-13/bin/.sockdump-wrapped", line 372, in main
      pcap_write_header(args.seg_size, PCAP_LINK_TYPE)
    File "/nix/store/dl5l4k2xrrxcay3hh9034p4jnfiq0ihg-sockdump-unstable-2023-07-13/bin/.sockdump-wrapped", line 313, in pcap_write_header
      sys.stdout.write(header)
  TypeError: write() argument must be str, not bytes
```

Explicitly opening the output file using the 'wb' mode for a pcap
capture.

Manually tested the patch on Python 3.10.12.