### PR TITLE
Remove deprecated `_pack` field

### DIFF
--- a/sockdump.py
+++ b/sockdump.py
@@ -234,7 +234,6 @@ def build_filter(sock_path):
     return filter, path_len, path_len_u64
 
 class Packet(ct.Structure):
-    _pack_ = 1
     _fields_ = [
         ('pid', ct.c_uint),
         ('peer_pid', ct.c_uint),


### PR DESCRIPTION
Currently, this causes the following deprecation warning on Python 3.14:

```
Due to '_pack_', the 'Packet' Structure will use memory layout compatible with MSVC (Windows).
If this is intended, set _layout_ to 'ms'.
The implicit default is deprecated and slated to become an error in Python 3.19.
```

Or is there a valid reason why this was originally set to `1`?