### PR TITLE
Properly display pathname of abstract sockets in hex and text output

### DIFF
--- a/sockdump.py
+++ b/sockdump.py
@@ -402,7 +402,6 @@ def main(args):
         else:
             sys.stdout.flush() # fflush buffer of current stdout
             sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb') # fdopen as binary
-            # sys.stdout = sys.stdout.buffer
         pcap_write_header(args.seg_size, PCAP_LINK_TYPE)
     else:
         if args.output != '/dev/stdout':

--- a/sockdump.py
+++ b/sockdump.py
@@ -242,7 +242,7 @@ class Packet(ct.Structure):
         ('len', ct.c_uint),
         ('flags', ct.c_uint),
         ('comm', ct.c_char * TASK_COMM_LEN),
-        ('path', ct.c_char * UNIX_PATH_MAX),
+        ('path', ct.c_byte * UNIX_PATH_MAX), # using c_byte to properly deal with leading \0 abstract UN*X domain sockets
         # variable length data
     ]
 
@@ -270,13 +270,24 @@ def parse_event(event, size):
 
     return packet, data
 
+def sanitize_pathname(pathname):
+    sanitized_pathname = bytearray(pathname)
+    # abstract UN*X domain socket?
+    if (sanitized_pathname[0] == 0):
+        sanitized_pathname[0] = ord('@')
+
+    # split at first string terminator
+    split_pathname = sanitized_pathname.split(b'\x00', 1)
+
+    return split_pathname[0] if len(split_pathname) > 1 else sanitized_pathname
+
 def print_header(packet, data):
     ts = time.time()
     ts = time.strftime('%H:%M:%S', time.localtime(ts)) + '.%03d' % (ts%1 * 1000)
 
     print('%s >>> process %s [%d -> %d] path %s len %d(%d)' % (
         ts, packet.comm.decode(), packet.pid, packet.peer_pid,
-        packet.path.decode(), len(data), packet.len))
+        sanitize_pathname(packet.path).decode(), len(data), packet.len))
 
 def string_output(cpu, event, size):
     global flush_after_each_packet

--- a/sockdump.py
+++ b/sockdump.py
@@ -242,7 +242,8 @@ class Packet(ct.Structure):
         ('len', ct.c_uint),
         ('flags', ct.c_uint),
         ('comm', ct.c_char * TASK_COMM_LEN),
-        ('path', ct.c_byte * UNIX_PATH_MAX), # using c_byte to properly deal with leading \0 abstract UN*X domain sockets
+         # using c_byte here to properly deal with the leading '\0' abstract UN*X domain sockets
+        ('path', ct.c_byte * UNIX_PATH_MAX),
         # variable length data
     ]
 
@@ -270,16 +271,21 @@ def parse_event(event, size):
 
     return packet, data
 
-def sanitize_pathname(pathname):
+def sanitize_pathname(pathname, replacement=0):
+    # create modifyable copy
     sanitized_pathname = bytearray(pathname)
-    # abstract UN*X domain socket?
+
+    start_idx = 0
+
+    # abstract UN*X domain socket? => replace leading '\0' with replacement
     if (sanitized_pathname[0] == 0):
-        sanitized_pathname[0] = ord('@')
+        start_idx = 1 if len(sanitized_pathname) > 1 else 0
+        sanitized_pathname[0] = replacement
 
-    # split at first string terminator
-    split_pathname = sanitized_pathname.split(b'\x00', 1)
+    # discard garbage starting with first end-of-string character (excluding the leading one)
+    eos_idx = sanitized_pathname.find(b'\x00', start_idx)
 
-    return split_pathname[0] if len(split_pathname) > 1 else sanitized_pathname
+    return sanitized_pathname if eos_idx == -1 else sanitized_pathname[:eos_idx]
 
 def print_header(packet, data):
     ts = time.time()
@@ -287,7 +293,7 @@ def print_header(packet, data):
 
     print('%s >>> process %s [%d -> %d] path %s len %d(%d)' % (
         ts, packet.comm.decode(), packet.pid, packet.peer_pid,
-        sanitize_pathname(packet.path).decode(), len(data), packet.len))
+        sanitize_pathname(packet.path, ord('@')).decode(), len(data), packet.len))
 
 def string_output(cpu, event, size):
     global flush_after_each_packet
@@ -357,7 +363,7 @@ def pcap_output(cpu, event, size):
     ts = time.time()
     ts_sec = int(ts)
     ts_usec = int((ts % 1) * 10**6)
-    header = struct.pack(f'>{UNIX_PATH_MAX + 1}pQQ', packet.path, packet.peer_pid, packet.pid)
+    header = struct.pack(f'>{UNIX_PATH_MAX + 1}pQQ', sanitize_pathname(packet.path), packet.peer_pid, packet.pid)
 
     data = header + data
     size = len(header) + packet.len

--- a/sockdump.py
+++ b/sockdump.py
@@ -302,7 +302,7 @@ def string_output(cpu, event, size):
     print_header(packet, data)
     if packet.flags & SS_PACKET_F_ERR:
         print('error')
-    print(str(data.raw, encoding='ascii', errors='ignore'), end='', flush=flush_after_each_event)
+    print(str(data.raw, encoding='ascii', errors='ignore'), end='', flush=flush_after_each_packet)
 
 def ascii(c):
     if c < 32 or c > 126:


### PR DESCRIPTION
The initial support for abstract sockets (a73c102f7b58b9d5b30346818281a8593a55d86f) lacks a special treatment of the pathname of abstract sockets upon output. - This effectively prevents the pathname of abstract sockets to be displayed in hex and text outputs.

To fix this, this PR does the following
* Substitute leading '\0' in pathname of abstract sockets by '@' in hex and text outputs
* No substitution is done for PCAP outputs since here we favor the raw information (i.e., the leading '\0')